### PR TITLE
Removal of the Windows Server issue for edit/view content

### DIFF
--- a/layouts/partials/hb/modules/content-panel/repo.html
+++ b/layouts/partials/hb/modules/content-panel/repo.html
@@ -29,8 +29,6 @@
     {{- with $page.File }}
       {{- $filepath = printf "%s%s" $subpath (strings.TrimPrefix $root .Filename) -}}
     {{- end }}
-    {{/* replace the path separator to / when running Hugo server on Windows. */}}
-    {{- $filepath = replace $filepath "\\" "/" }}
     {{- $editURL := printf .editURL $baseURL $branch $filepath }}
     {{- $viewURL := printf .viewURL $baseURL $branch $filepath }}
     {{- $commitURL := .commitURL }}


### PR DESCRIPTION
When running HUGO server in development on my windows machine there edit URL wasn't working correctly.

Maybe something later in the change fixed the issue, so removing this line ensures that the URL to edit/view are correct.

Before instead of / it placed in %5c example:
`%5ccontent%5cblog%5cmy-first-hugo.io-post%5cindex.md`
now get
`/content/blog/my-first-hugo.io-post/index.md`

removal of the line in this pull request has made the link work correctly when running hugo via 
`npm run dev`